### PR TITLE
fix: change where SEND_CONTRACT_TX action type is imported from

### DIFF
--- a/packages/store/src/DrizzleContract.js
+++ b/packages/store/src/DrizzleContract.js
@@ -111,7 +111,7 @@ class DrizzleContract {
       // Dispatch tx to saga
       // When txhash received, will be value of stack ID
       contract.store.dispatch({
-        type: TransactionsActions.SEND_CONTRACT_TX,
+        type: ContractActions.SEND_CONTRACT_TX,
         contract,
         fnName,
         fnIndex,


### PR DESCRIPTION
Closes #77

To resolve the above issue, in the DrizzleContract.js file in the Drizzle store, the action type referenced as `TransactionsActions.SEND_CONTRACT_TX` has been changed to`ContractActions.SEND_CONTRACT_TX`. The action type `SEND_CONTRACT_TX` can now be accessed there because it is defined as a constant in the file './contracts/constants', which is imported as `ContractActions` in DrizzleContract.js. 

_To test that the proposed change fixes the issue:_ 
- Run `yarn` to build (the console output from the compilation should no longer show a warning about this issue)
- In the Drizzle Custom Provider example, submit a new stored value, and the value should update correctly
